### PR TITLE
reorganised nixosRoles structure

### DIFF
--- a/nixosRoles/default.nix
+++ b/nixosRoles/default.nix
@@ -15,50 +15,9 @@ in
 {
 
   imports = [
-    ### System related roles ###
-    #    ./common.nix
-    ./system/deployUser.nix
-    ./system/sops.nix
-    ./system/proxmoxContainer.nix
-    ./system/containerSettings.nix
-    ./system/vmSettings.nix
-    ./system/flakeSettings.nix
-    ./system/qsv.nix
-    ./system/updateSettings.nix
-    ./system/localisation.nix
-    ./system/packages.nix
-    ./system/users.nix
-    ./system/networking.nix
-    ./system/aliases.nix
-    ./system/zsh.nix
-    ./system/fish.nix
-    #    ./system/nvf.nix
-    ./system/nixvim.nix
-    ./system/fonts.nix
-    ./system/deployMachine.nix
-    ./system/impermanence.nix
-    ### Service related roles ###
-    ./services/acme.nix
-    ./services/jellyfin.nix
-    ./services/ssh.nix
-    ./services/tailscale.nix
-    ./services/docker.nix
-    ./services/technitium-dns.nix
-    ./services/glances.nix
-    ./services/nginx.nix
-    ./services/nextcloud.nix
-    ./services/gotify.nix
-    ./services/immich.nix
-    ./services/borgbackupServer.nix
-    ./services/flakeAutoUpdateSvr.nix
-    ./services/beszel.nix
-    ./services/vscode-server.nix
-    ./services/prometheus-exporter.nix
-    ./services/promtail.nix
-    ./services/influxdb.nix
-    ./services/grafanaStack.nix
-    ### More complex custom roles ###
-    ./options/borgClient.nix
+    ./system
+    ./services
+    ./options
   ];
 
   roles = {

--- a/nixosRoles/options/default.nix
+++ b/nixosRoles/options/default.nix
@@ -1,0 +1,10 @@
+{
+  ...
+}:
+{
+
+  imports = [
+    ./borgClient.nix
+  ];
+
+}

--- a/nixosRoles/services/default.nix
+++ b/nixosRoles/services/default.nix
@@ -1,0 +1,28 @@
+{
+  ...
+}:
+{
+
+  imports = [
+    ./acme.nix
+    ./beszel.nix
+    ./borgbackupServer.nix
+    ./docker.nix
+    ./flakeAutoUpdateSvr.nix
+    ./glances.nix
+    ./gotify.nix
+    ./grafanaStack.nix
+    ./immich.nix
+    ./influxdb.nix
+    ./jellyfin.nix
+    ./nextcloud.nix
+    ./nginx.nix
+    ./prometheus-exporter.nix
+    ./promtail.nix
+    ./ssh.nix
+    ./tailscale.nix
+    ./technitium-dns.nix
+    ./vscode-server.nix
+  ];
+
+}

--- a/nixosRoles/system/default.nix
+++ b/nixosRoles/system/default.nix
@@ -1,0 +1,28 @@
+{
+  ...
+}:
+{
+
+  imports = [
+    ./aliases.nix
+    ./containerSettings.nix
+    ./deployMachine.nix
+    ./deployUser.nix
+    ./fish.nix
+    ./flakeSettings.nix
+    ./fonts.nix
+    ./impermanence.nix
+    ./networking.nix
+    ./nixvim.nix
+    ./localisation.nix
+    ./packages.nix
+    ./proxmoxContainer.nix
+    ./qsv.nix
+    ./sops.nix
+    ./updateSettings.nix
+    ./users.nix
+    ./vmSettings.nix
+    ./zsh.nix
+  ];
+
+}


### PR DESCRIPTION
Simplified nixosRoles structure by moving imports to default.nix, paving the way to breakout roles directories further.